### PR TITLE
Поиск: starts-with на substring, дедупликация книг

### DIFF
--- a/client/components/Search/BaseList.js
+++ b/client/components/Search/BaseList.js
@@ -591,7 +591,7 @@ export default class BaseList {
                 const re = new RegExp(searchValue, 'i');
                 return re.test(bookValue);
             } else {
-                return bookValue.indexOf(searchValue) === 0;
+                return bookValue !== emptyFieldValue && bookValue.indexOf(searchValue) >= 0;
             }
         };
 

--- a/client/components/Search/Search.vue
+++ b/client/components/Search/Search.vue
@@ -1508,8 +1508,6 @@ class Search {
                 if (v) {
                     if (v[0] === '=')
                         v = v.substring(1);
-                    else if (!specSym.has(v[0]))
-                        v = '^' + v;
                 }
                 return v || '';
             };

--- a/client/components/Search/TitleList/TitleList.vue
+++ b/client/components/Search/TitleList/TitleList.vue
@@ -95,14 +95,27 @@ class TitleList extends BaseList {
             if (rec.books) {
                 const filtered = this.filterBooks(rec.books);
 
-                for (let i = 0; i < filtered.length; i++) {
+                const seen = new Map();
+                for (const book of filtered) {
+                    const key = book.libid || book.file || book.id;
+                    if (seen.has(key)) {
+                        const existing = seen.get(key);
+                        if (book.series && !existing.series.split(';').map(s => s.trim()).includes(book.series))
+                            existing.series += '; ' + book.series;
+                    } else {
+                        seen.set(key, {...book});
+                    }
+                }
+                const deduped = [...seen.values()];
+
+                for (let i = 0; i < deduped.length; i++) {
                     if (i === 0)
-                        item.book = filtered[i];
+                        item.book = deduped[i];
                     else
-                        item.books.push(filtered[i]);                    
+                        item.books.push(deduped[i]);                    
                 }
 
-                if (filtered.length) {
+                if (deduped.length) {
                     num++;
                     result.push(item);
                 }

--- a/server/core/DbSearcher.js
+++ b/server/core/DbSearcher.js
@@ -81,7 +81,7 @@ class DbSearcher {
                 })()
             `;
         } else {
-            where = `@dirtyIndexLR('value', ${db.esc(a)}, ${db.esc(a + maxUtf8Char)})`;
+            where = `@indexIter('value', (v) => (v !== ${db.esc(emptyFieldValue)} && v.indexOf(${db.esc(a)}) >= 0) )`;
         }
 
         return where;

--- a/server/core/DbSearcher.js
+++ b/server/core/DbSearcher.js
@@ -712,8 +712,7 @@ class DbSearcher {
                     `;
                 } else {
 
-                    return `(row.${bookField}.toLowerCase().localeCompare(${db.esc(searchValue)}) >= 0 ` +
-                        `&& row.${bookField}.toLowerCase().localeCompare(${db.esc(searchValue)} + ${db.esc(maxUtf8Char)}) <= 0)`;
+                    return `(row.${bookField} && row.${bookField}.toLowerCase().indexOf(${db.esc(searchValue)}) >= 0)`;
                 }
             };
 

--- a/server/core/opds/BasePage.js
+++ b/server/core/opds/BasePage.js
@@ -302,8 +302,7 @@ class BasePage {
                 const re = new RegExp(searchValue, 'i');
                 return re.test(bookValue);
             } else {
-                //where = `@dirtyIndexLR('value', ${db.esc(a)}, ${db.esc(a + maxUtf8Char)})`;
-                return bookValue.localeCompare(searchValue) >= 0 && bookValue.localeCompare(searchValue + maxUtf8Char) <= 0;
+                return bookValue !== emptyFieldValue && bookValue.indexOf(searchValue) >= 0;
             }
         };
 


### PR DESCRIPTION
**Проблема 1** — поиск не находил книги с кавычками

Поиск без префикса искал только книги, названия которых НАЧИНАЮТСЯ с введённого текста. Если название начинается с кавычек (ёлочек «, прямых ") или скобок, поиск по тексту после них ничего не находил.

Пример: книга «Название» не находилась по запросу "Название" — строка начинается с «, а не с Н.

Исправлено: поиск по умолчанию теперь ищет подстроку в любом месте. Префиксы = * # ~ работают без изменений.

**Проблема 2** — дублирование книг в поиске по названиям

Книга в нескольких сериях показывалась несколько раз (разные ID, один файл). Исправлено: группировка по libid, серии перечислены через ;

**Проблема 3** — маркер ^ в заголовке

Убран, больше не актуален.

Файлы: DbSearcher.js, BaseList.js, BasePage.js, TitleList.vue, Search.vue