### PR TITLE
Properly named kepub format file name for Kobo ereaders

### DIFF
--- a/server/core/BookConverter.js
+++ b/server/core/BookConverter.js
@@ -14,12 +14,22 @@ const fb2cngFormats = new Map([
     ['azw8', 'azw8'],
 ]);
 const fb2cngOutputExtensions = new Map([
-    ['epub', ['.epub']],
-    ['epub3', ['.epub']],
-    ['kepub', ['.kepub.epub', '.epub']],
-    ['kfx', ['.kfx']],
-    ['azw8', ['.azw8']],
+    ['epub3', 'epub'],
+    ['kepub', 'kepub.epub'],
 ]);
+
+function getConvertedExtension(fileType) {
+    const outputExtension = fb2cngOutputExtensions.get(fileType) || fileType.toLowerCase();
+    return outputExtension;
+};
+
+function getConvertedFileName(originalFileName, format) {
+    const ext = path.extname(originalFileName);
+    const base = (ext ? originalFileName.slice(0, -ext.length) : originalFileName);
+    const extNew = getConvertedExtension(format);
+    return `${base}.${extNew}`;
+}
+
 function bundledToolPath(fileName) {
     const dir = bundledBinDir();
     return dir ? path.join(dir, fileName) : '';
@@ -161,10 +171,11 @@ async function convertWithFb2cng(inputFile, outputFile, format, converterPaths =
     await fs.ensureDir(outputDir);
     await runFirst(fb2cngCommandCandidates(converterPaths), ['convert', '--to', fb2cngFormat, '--overwrite', inputFile, outputDir]);
 
-    const outputExtensions = fb2cngOutputExtensions.get(format) || [`.${format}`];
-    const converted = (await fs.readdir(outputDir))
-        .filter(file => outputExtensions.some(ext => file.toLowerCase().endsWith(ext)))
-        .map(file => path.join(outputDir, file))[0];
+    const outputExtension = `.${getConvertedExtension(format)}`;
+    const firstMatchedFile = (await fs.readdir(outputDir))
+        .find(file => file.toLowerCase().endsWith(outputExtension));
+    const converted = firstMatchedFile ? path.join(outputDir, firstMatchedFile) : undefined;
+
 
     if (!converted)
         throw new Error(`fb2cng did not produce ${format}`);
@@ -254,4 +265,6 @@ module.exports = {
     mutoolCommandCandidates,
     calibreCommandCandidates,
     convert,
+    getConvertedFileName,
+    getConvertedExtension,
 };

--- a/server/core/WebWorker.js
+++ b/server/core/WebWorker.js
@@ -550,12 +550,6 @@ function formatTemplate(template, book = {}) {
         .replace(/\$\{EXT\}/g, book.ext || '');
 }
 
-function convertedFileName(downFileName, format) {
-    const ext = path.extname(downFileName);
-    const base = (ext ? downFileName.slice(0, -ext.length) : downFileName);
-    return `${base}.${format}`;
-}
-
 function buildAuthorVariants(author) {
     const result = new Set();
     const normalized = normalizeAuthorText(author);
@@ -5295,7 +5289,7 @@ class WebWorker {
                 });
                 cacheChanged = true;
             }
-            preparedFileName = convertedFileName(downFileName, targetFormat);
+            preparedFileName = bookConverter.getConvertedFileName(downFileName, targetFormat);
             await utils.touchFile(preparedFile);
         }
 

--- a/server/static.js
+++ b/server/static.js
@@ -41,19 +41,6 @@ function generateZip(zipFile, dataFile, dataFileInZip) {
     });
 }
 
-function convertedFileName(downFileName, format) {
-    const ext = path.extname(downFileName);
-    const base = (ext ? downFileName.slice(0, -ext.length) : downFileName);
-    return `${base}.${format}`;
-}
-
-function normalizedRawFileName(downFileName, fileType) {
-    if (fileType === 'raw' || fileType === undefined)
-        return downFileName;
-
-    return downFileName;
-}
-
 function normalizeLibraryDir(dir = '') {
     return String(dir || '').replace(/\\/g, '/').replace(/\/+$/g, '');
 }
@@ -459,7 +446,6 @@ module.exports = (app, config) => {
 
                         if (fileType === undefined || fileType === 'raw') {
                             bookFile = rawFile;
-                            downFileName = normalizedRawFileName(downFileName, fileType);
                         } else if (fileType === 'zip') {
                             //создаем zip-файл
                             bookFile += '.zip';
@@ -473,10 +459,10 @@ module.exports = (app, config) => {
                             if (!config.conversionEnabled)
                                 throw new Error('Book conversion is disabled in this image');
 
-                            bookFile += `.${fileType}`;
+                            bookFile += `.${bookConverter.getConvertedExtension(fileType)}`;
                             if (!await fs.pathExists(bookFile))
                                 await bookConverter.convert({inputFile: rawFile, outputFile: bookFile, format: fileType, sourceFileName: downFileName});
-                            downFileName = convertedFileName(downFileName, fileType);
+                            downFileName = bookConverter.getConvertedFileName(downFileName, fileType);
                         } else {
                             throw new Error(`Unsupported file type: ${fileType}`);
                         }


### PR DESCRIPTION
Reason: Kobo ereaders don't recognize files with .kepub extension. Requires .kepub.epub extension in order for them to work.

BookConverter:
- Extension getter getExtensionByFileType added for re-usability
- Redundant values removed from fb2cngOutputExtensions map, getExtensionByFileType covers the rest. Matches original behavior(from line 164)
- File extensions changed from list to pure strings with no leading period.
- Converted file search optimized

static.js:
- Changes were made to return a properly named kepub file for Kobo ereaders using getExtensionByFileType from BookConverter.
- Redundant function and function call removed.